### PR TITLE
Don't display attorney details

### DIFF
--- a/app/views/documents/show.html.haml
+++ b/app/views/documents/show.html.haml
@@ -41,13 +41,11 @@
             %thead
               %tr
                 %th Name
-                %th Company/Law Firm
                 %th Score
                 %th Explanation
             %tbody
               - rating.bullet_point.ratings.for_document(@document).preload(:review => :user).each do |lawyer_rating|
                 %tr
-                  %td= link_to "#{lawyer_rating.review.user.first_name} #{lawyer_rating.review.user.last_name}", lawyer_rating.review.user
-                  %td= lawyer_rating.review.user.company_name
+                  %td.cell_collapse= link_to "#{lawyer_rating.review.user.first_name} #{lawyer_rating.review.user.last_name[0]}", lawyer_rating.review.user
                   %td= lawyer_rating.score
                   %td= simple_format lawyer_rating.description

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -8,18 +8,7 @@
       %span.glyphicon.glyphicon-pencil
       Edit
 
-  %h1= [@user.first_name, @user.last_name].join(' ')
-
-%dl.dl-horizontal
-  %dt Email:
-  %dd= @user.email
-  %dt Website:
-  %dd= link_to @user.website, @user.website, target: '_blank'
-  %dt Company name:
-  %dd= @user.company_name
-  - if @user.description.present?
-    %dt Description:
-    %dd= @user.description
+  %h1= [@user.first_name, @user.last_name[0]].join(' ')
 
 %h2 Reviews
 %table.table.table-striped.table-bordered.table-hover


### PR DESCRIPTION
Per request from Otto and Katherine, hide attorney details to protect their privacy.
- [ ] Hide on:
  - [x] users#show
  - [x] documents#show
  - [ ] anywhere else ...?
- [ ] Truncate last name to first letter (I sort of did this on the above views, but I didn't add a period to the last name. Kinda wonder if there's any benefit to showing the first letter at all, or if it should just be the first name -- Jeremy)

I removed all of the details that I saw, but maybe a topic for discussion next time we meet with Katherine and Otto.