### PR TITLE
Better URL parsing/matching.

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -73,7 +73,7 @@ class DocumentsController < ApplicationController
 
   # GET /documents/find.json?document_url=url
   def find
-    @document = Document.find_by_url(params[:document_url])
+    @document = Document.search_for_url(params[:document_url])
     @review = Review.find_review_for(@document, cookies[:email])
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,8 @@
 class Document < ApplicationRecord
   belongs_to :document_type
   has_many :reviews, dependent: :destroy
-  validates_uniqueness_of :url
+  before_validation :record_parsed_uri, if: :will_save_change_to_url? # url_changed?
+  validate :valid_unique_url
 
   def self.search(query)
     scope = includes(:document_type, :reviews)
@@ -13,17 +14,23 @@ class Document < ApplicationRecord
     scope.all.order("company_name DESC")
   end
 
-  def summarize_scores
-    @summarize_scores = Review.summarize_scores(self)
+  # Returns a document by the hostname and path given,
+  # If there is no path, maybe the site does it's url
+  # exclusively via query params... so search by
+  # the host + query instead.
+  def self.search_for_url(url)
+    uri = URI.parse(url)
+    docs = where(uri_host: uri.host.to_s.sub(/^www\./, ""))
+    if uri.path.present?
+      docs = docs.where(uri_path: uri.path)
+    else
+      docs = docs.where(uri_path: uri.path, uri_query: uri.query)
+    end
+    return docs.last
   end
 
-  def url
-    the_url = super
-    if the_url =~ %r{^https?://} || the_url.blank?
-      the_url
-    else
-      "http://#{the_url}"
-    end
+  def summarize_scores
+    @summarize_scores = Review.summarize_scores(self)
   end
 
   def overall_score
@@ -31,6 +38,50 @@ class Document < ApplicationRecord
       scores = Review.summarize_scores(self).map(&:avg_score)
       return nil if scores.empty?
       scores.sum / scores.size
+    end
+  end
+
+  private
+
+  # before_validation
+  def record_parsed_uri
+    self.url = if url.to_s =~ %r{https?://} || url.blank?
+      url
+    else
+      "http://#{url}"
+    end
+
+    uri = URI.parse(self.url)
+    # Don't save the 'www.' part of the host, so that something like
+    # "facebook.com" and "www.facebook.com" will both match,
+    # but "apps.facebook.com" will not.
+    self.uri_host = uri.host.sub(/^www\./, "")
+    self.uri_path = uri.path
+    self.uri_query = uri.query
+    self.uri_fragment = uri.fragment
+  rescue URI::InvalidURIError
+    self.uri_host = nil
+    self.uri_path = nil
+    self.uri_query = nil
+    self.uri_fragment = nil
+  end
+
+  def valid_unique_url
+    if uri_host.blank?
+      errors.add(:url, "appears to be invalid")
+      return false
+    end
+
+    docs = Document
+    unless new_record?
+      # Exclude self id if this is an update on an
+      # existing record.
+      docs = docs.where.not(id: self.id)
+    end
+    docs = docs.search_for_url(self.url)
+
+    if docs.present?
+      errors.add(:url, "must be unique")
     end
   end
 end

--- a/db/migrate/20180306192351_add_uri_parse_to_document.rb
+++ b/db/migrate/20180306192351_add_uri_parse_to_document.rb
@@ -1,0 +1,17 @@
+class AddUriParseToDocument < ActiveRecord::Migration[5.1]
+  def change
+    add_column :documents, :uri_host, :text
+    add_column :documents, :uri_path, :text
+    add_column :documents, :uri_query, :text
+    add_column :documents, :uri_fragment, :text
+
+    # sets up existing docs to have the correct
+    # uri parses.
+    Document.all.each do |document|
+      document.send(:record_parsed_uri) if document.url.present?
+      if !document.save
+        puts "Document #{document.id} (#{document.name}) could not be saved: #{document.errors.full_messages.join(', ')}"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180225181133) do
+ActiveRecord::Schema.define(version: 20180306192351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,10 @@ ActiveRecord::Schema.define(version: 20180225181133) do
     t.bigint "document_type_id"
     t.string "version"
     t.text "company_name"
+    t.text "uri_host"
+    t.text "uri_path"
+    t.text "uri_query"
+    t.text "uri_fragment"
     t.index ["document_type_id"], name: "index_documents_on_document_type_id"
   end
 


### PR DESCRIPTION
Now storing URI fragments (host, path, query, fragment) directly on document model
so that we can more easily determine proper URL uniqueness and better url searching from the extension. This will let erroneous things like nonsense from query params or nonsense fragments not interfere with the ability to find a document by the url.

For instance, if a document is saved like this:

"http://facebook.com/terms"

but a user visits:

"https://www.facebook.com/terms"

the old version would not recognize the terms page, this new method will.

We can also extend the extension to know that it is on a *site* with reviewed document(s) since we can search by host, instead of only highlighting the extension when you're on an exact contract page.